### PR TITLE
Add LSB tags

### DIFF
--- a/templates/kafka-init.sh.j2
+++ b/templates/kafka-init.sh.j2
@@ -1,5 +1,15 @@
 #!/bin/sh
 # Copyright (C) 2016 Wesley Tanaka
+### BEGIN INIT INFO
+# Provides:          kafka
+# Required-Start:
+# Required-Stop:
+# Should-Start: $network
+# Default-Start:     2 3 4 5
+# Default-Stop :     0 1 6
+# Short-Description: Start Kafka broker
+# Description:       Runs kafka-server-start.sh from kafka distribution
+### END INIT INFO
 
 case $1 in
    start)


### PR DESCRIPTION
to fix:

insserv: warning: script 'kafka-0.sh' missing LSB tags and overrides
insserv: There is a loop between service monit and kafka-0.sh if stopped
insserv:  loop involving service kafka-0.sh at depth 2
insserv:  loop involving service monit at depth 1
insserv: Stopping kafka-0.sh depends on monit and therefore on system facility
   `$all' which can not be true!
insserv: exiting now without changing boot order!
update-rc.d: error: insserv rejected the script header