### PR TITLE
Restart kafka on configuration change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,9 @@
   sudo: yes
   when: not (is_integration_test is defined and is_integration_test and
       (ansible_os_family == "RedHat" or ansible_distribution == "CentOS"))
+
+- name: restart kafka
+  shell: '/etc/init.d/kafka.sh stop && /etc/init.d/kafka.sh start'
+  sudo: yes
+  when: not (is_integration_test is defined and is_integration_test and
+      (ansible_os_family == "RedHat" or ansible_distribution == "CentOS"))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,7 +79,7 @@
     src=server.properties.j2
     dest={{kafka_install_dir}}/config/{%if 'file_basename' in item%}{{item.file_basename}}{%else%}{{kafka_default_file_basename_prefix}}{{item.broker_id}}{%endif%}.properties
     owner={{kafka_user}}
-  notify: restart monit
+  notify: restart kafka
 
 - name: Install kafka init wrapper
   sudo: True


### PR DESCRIPTION
Restarting monit doesn't restarts kafka, so if you change kafka configuration it will not be applied after provisioning update.