### PR TITLE
Systemd service file correct directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,7 @@
   with_items: "{{kafka_brokers}}"
   template: >
     src=kafka-systemd.service.j2
-    dest=/etc/init.d/{%if 'file_basename' in item%}{{item.file_basename}}{%else%}{{kafka_default_file_basename_prefix}}{{item.broker_id}}{%endif%}.service
+    dest=/etc/systemd/system/{%if 'file_basename' in item%}{{item.file_basename}}{%else%}{{kafka_default_file_basename_prefix}}{{item.broker_id}}{%endif%}.service
     owner=root
     mode=0755
   when: (ansible_distribution == 'CentOS' and ansible_distribution_major_version > '6')


### PR DESCRIPTION
Minor change since last PR, I noticed I have mistakenly put systemd service file into init.d directory which is incorrect. After some operation on the servers I found this to be appropriate directory for systemd service file.