### PR TITLE
Force update feature flag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ kafka_scala_version: "2.11"
 kafka_mirror: 'http://archive.apache.org/dist/kafka'
 kafka_dl_tmp_dir: "/tmp"
 kafka_install_chdir: "/opt"
+# true to force in place binary update (IE: minor version)
+kafka_force_update: false
 kafka_user: "kafka"
 kafka_user_shell: "/bin/bash"
 kafka_monit_enabled: true

--- a/tasks/untar_kafka.yml
+++ b/tasks/untar_kafka.yml
@@ -9,7 +9,7 @@
     creates: "{{kafka_dl_tmp_dir}}/{{kafka_archive}}"
   register: result_download_kafka
   until: result_download_kafka|success
-  when: (install.stat.isdir is not defined or not install.stat.isdir)
+  when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
 
 - name: Make unpack directory
   sudo: True
@@ -17,19 +17,19 @@
     path: "{{kafka_tmp_unpack_dir}}"
     owner: "{{kafka_user}}"
     state: directory
-  when: (install.stat.isdir is not defined or not install.stat.isdir)
+  when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
 
 - name: Unpack kafka
   command: tar xvfoz "{{kafka_dl_tmp_dir}}/{{kafka_archive}}" --strip-components 1
   sudo: True
-  when: (install.stat.isdir is not defined or not install.stat.isdir)
+  when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
   args:
     chdir: "{{kafka_tmp_unpack_dir}}"
 
 - name: Move into place
   command: mv {{kafka_tmp_unpack_dir}} {{kafka_install_dir}}
   sudo: True
-  when: (install.stat.isdir is not defined or not install.stat.isdir)
+  when: (install.stat.isdir is not defined or not install.stat.isdir or kafka_force_update)
   args:
     creates: "{{kafka_install_dir}}"
 


### PR DESCRIPTION
Useful when needing to do in place code swap for minor upgrade.

Full fledged version should use different path perversion + symlink to install directory - but this is a good enough option for system needing force upgrade.