### PR TITLE
Python 3 support - iteritems bug

### DIFF
--- a/templates/kafka-init.sh.j2
+++ b/templates/kafka-init.sh.j2
@@ -11,7 +11,7 @@
 # Description:       Runs kafka-server-start.sh from kafka distribution
 ### END INIT INFO
 
-{% for name, value in kafka_env_variables.iteritems() %}
+{% for name, value in (kafka_env_variables.items() | list) %}
 {{name}}='{{value}}'
 export {{name}}
 {% endfor %}

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -11,9 +11,9 @@ log.dirs={%if 'log_dirs' in item%}{{item.log_dirs}}{%else%}{{kafka_default_topic
 {% if kafka_delete_topic_enable is defined %}
 delete.topic.enable={{kafka_delete_topic_enable}}
 {% endif %}
-{% for config_key, config_value in kafka_config_contents.iteritems() %}
+{% for config_key, config_value in (kafka_config_contents.items() | list) %}
 {{config_key}}={{config_value}}
 {% endfor %}
-{% for config_key, config_value in kafka_more_config.iteritems() %}
+{% for config_key, config_value in (kafka_more_config.items() | list) %}
 {{config_key}}={{config_value}}
 {% endfor %}


### PR DESCRIPTION
`iteritems()` has been removed in Python3 - but `items` is available in Python2/3 and backward compatible.

Error caused by iteritems 
```
TASK [apache-kafka : Install kafka broker server config] *************************************************************************************************************************************************************************************
failed: [XXXXXXXX] (item={'listeners': 'PLAINTEXT://XXXXXX', 'file_basename': 'kafka', 'log_dirs': '/kafka/logs'}) => {"changed": false, "item": {"file_basename": "kafka", "listeners": "PLAINTEXT://XXXXXX", "log_dirs": "/kafka/logs"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}
```

Fixed in this PR