### PR TITLE
Ansible 2.9 |success nomenclature deprecation

### DIFF
--- a/tasks/compat.yml
+++ b/tasks/compat.yml
@@ -9,7 +9,7 @@
              (apt-get update -qq && apt-get install -y python-apt)));
     fi
   register: result_python_apt
-  until: result_python_apt|success
+  until: result_python_apt is success
   when: ansible_os_family == 'Debian'
   changed_when: False
 
@@ -23,7 +23,7 @@
              (apt-get update -qq && apt-get install -y python-pycurl)));
     fi
   register: result_python_pycurl
-  until: result_python_pycurl|success
+  until: result_python_pycurl is success
   when: ansible_os_family == 'Debian'
   changed_when: False
 
@@ -35,7 +35,7 @@
        (> /dev/null command -v yum && ! > /dev/null command -v dnf && yum install -y python2-yum);
     fi
   register: result_python_yum
-  until: result_python_yum|success
+  until: result_python_yum is success
   when: ansible_os_family == 'RedHat'
   changed_when: False
 
@@ -47,7 +47,7 @@
        (> /dev/null command -v dnf && dnf install -y python2-dnf);
     fi
   register: result_python_dnf
-  until: result_python_dnf|success
+  until: result_python_dnf is success
   when: ansible_os_family == 'RedHat'
   changed_when: False
 
@@ -62,11 +62,11 @@
 
 - set_fact:
     backcompat_pkg_mgr: 'dnf'
-  when: ansible_os_family == 'RedHat' and dnf_result|success
+  when: ansible_os_family == 'RedHat' and dnf_result is success
 
 - set_fact:
     backcompat_pkg_mgr: '{{ansible_pkg_mgr}}'
-  when: ansible_os_family == 'RedHat' and dnf_result|failed
+  when: ansible_os_family == 'RedHat' and dnf_result is failed
 
 - set_fact:
     backcompat_pkg_mgr: '{{ansible_pkg_mgr}}'
@@ -92,19 +92,19 @@
 - name: install wget with non-dnf
   action: "{{backcompat_pkg_mgr}} name=wget"
   register: result_wget
-  until: result_wget|success
+  until: result_wget is success
   sudo: yes
   when: >
     (backcompat_pkg_mgr == "yum" or backcompat_pkg_mgr == "apt")
-       and wget_result|failed
+       and wget_result is failed
 
 # Install wget due to https://github.com/ansible/ansible/issues/12161
 # Use command since dnf was only added as a module in ansible 1.9.0
 - name: install wget with dnf
   command: dnf install -y wget
   register: result_wget_dnf
-  until: result_wget_dnf|success
+  until: result_wget_dnf is success
   args:
     creates: /usr/bin/wget
   sudo: yes
-  when: backcompat_pkg_mgr == "dnf" and wget_result|failed
+  when: backcompat_pkg_mgr == "dnf" and wget_result is failed

--- a/tasks/create_user.yml
+++ b/tasks/create_user.yml
@@ -13,7 +13,7 @@
     comment: "Kafka user"
     shell: "{{kafka_user_shell}}"
     password: "*"
-  when: id_result|failed
+  when: id_result is failed
 #
 #- name: Enable ssh on kafka user
 #  sudo: True

--- a/tasks/epel.yml
+++ b/tasks/epel.yml
@@ -2,7 +2,7 @@
 - name: Install redhat-lsb
   sudo: yes
   register: result_redhat_lsb
-  until: result_redhat_lsb|success
+  until: result_redhat_lsb is success
   yum:
     name: redhat-lsb
     state: present
@@ -17,7 +17,7 @@
 - name: Install EPEL repo.
   sudo: yes
   register: result_epel_release
-  until: result_epel_release|success
+  until: result_epel_release is success
   yum:
     name: epel-release
     state: present

--- a/tasks/install_package_names.yml
+++ b/tasks/install_package_names.yml
@@ -3,7 +3,7 @@
   action: "{{backcompat_pkg_mgr}} name={{item}}"
   sudo: yes
   register: result_default
-  until: result_default|success
+  until: result_default is success
   when: >
     package_names is defined and
     (backcompat_pkg_mgr == "yum" or backcompat_pkg_mgr == "apt")
@@ -22,7 +22,7 @@
   command: dnf install -y {{package_names | join(' ')}}
   sudo: yes
   register: result_dnf
-  until: result_dnf|success
+  until: result_dnf is success
   when: >
     package_names is defined and backcompat_pkg_mgr == "dnf" and
-    package_exists_result|failed
+    package_exists_result is failed

--- a/tasks/untar_kafka.yml
+++ b/tasks/untar_kafka.yml
@@ -8,7 +8,7 @@
   args:
     creates: "{{kafka_dl_tmp_dir}}/{{kafka_archive}}"
   register: result_download_kafka
-  until: result_download_kafka|success
+  until: result_download_kafka is success
   when: (install.stat.isdir is not defined or not install.stat.isdir)
 
 - name: Make unpack directory


### PR DESCRIPTION
This get rid of deprecation warning 
```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|failed` use `result is failed`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False
 in ansible.cfg.
```

Simple solution is to replace `|` with `is`